### PR TITLE
Fix ordinal suffix in commit message in update.go

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -73,7 +73,7 @@ func main() {
 	}
 
 	// Note: All files in the directory will be added and committed (except those ignored by a .gitignore)
-	date := time.Now().Format("2nd of Jan 2006")
+	date := time.Now().Format("2 January 2006")
 	err = tldrGit.CommitAll(UpstreamDir, "Daily update - "+date)
 	if err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
28nd, 1nd, 3nd, 4nd, 5nd, 6nd, etc., are wrong :P

Change the date format to a more locale-agnostic format

By the way, love this project! :heart:

We're going to add it to the [main tldr readme](https://github.com/tldr-pages/tldr/blob/41a52313834b72cec3aad7ac7ca7c1317eda3bfb/README.md)!