### PR TITLE
Dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Dark mode (#12)
 
 ## [1.2.0] - 29th May 2021
 - Brand-new web interface built using Geist UI (#11)

--- a/resources/src/App.tsx
+++ b/resources/src/App.tsx
@@ -1,4 +1,5 @@
-import { GeistProvider, Page, Text } from '@geist-ui/react'
+import { CssBaseline, GeistProvider, Page, Text } from '@geist-ui/react'
+import { ThemeTypeProvider, useThemeType } from './ThemeType'
 import { DataFetcher } from './Data'
 import { DataTable } from './Table'
 import { AppLoader } from './AppLoader'
@@ -9,22 +10,33 @@ import 'inter-ui/inter.css'
 import './App.css'
 
 const App = () => (
-  <GeistProvider>
-    <Page size="large" style={{ minHeight: '1px' }}>
-      <Page.Header>
-        <Text h1>tldr translation progress</Text>
-      </Page.Header>
-      <Page.Content>
-        <DataFetcher loading={<AppLoader />} error={<ErrorMessage />}>
-          <IconActions />
-          <DataTable />
-        </DataFetcher>
-      </Page.Content>
-      <Page.Footer style={{ position: 'static' }}>
-        <AppFooter />
-      </Page.Footer>
-    </Page>
-  </GeistProvider>
+  <ThemeTypeProvider>
+    <GeistApp />
+  </ThemeTypeProvider>
 )
+
+const GeistApp = () => {
+  const themeType = useThemeType()
+
+  return (
+    <GeistProvider themeType={themeType}>
+      <CssBaseline />
+      <Page size="large" style={{ minHeight: '1px' }} className={themeType}>
+        <Page.Header>
+          <Text h1>tldr translation progress</Text>
+        </Page.Header>
+        <Page.Content>
+          <DataFetcher loading={<AppLoader />} error={<ErrorMessage />}>
+            <IconActions />
+            <DataTable />
+          </DataFetcher>
+        </Page.Content>
+        <Page.Footer style={{ position: 'static' }}>
+          <AppFooter />
+        </Page.Footer>
+      </Page>
+    </GeistProvider>
+  )
+}
 
 export { App }

--- a/resources/src/IconActionHelp.tsx
+++ b/resources/src/IconActionHelp.tsx
@@ -1,5 +1,13 @@
 import { useContext } from 'react'
-import { ArrowDownCircle, Bookmark, Filter, HelpCircle, Search } from '@geist-ui/react-icons'
+import {
+  ArrowDownCircle,
+  Bookmark,
+  Filter,
+  HelpCircle,
+  Moon,
+  Search,
+  Sun,
+} from '@geist-ui/react-icons'
 import { Link, Modal, Text, Tooltip, useModal } from '@geist-ui/react'
 import { DataContext } from './Data'
 import { useEscClose } from './useEscClose'
@@ -41,6 +49,8 @@ const HelpContent = () => (
     <Text h3>actions</Text>
     <Text p>
       <HelpCircle size={20} className="vertical-align-icons" /> - get help (this page) <br />
+      <Moon size={20} className="vertical-align-icons" /> - switch to the dark mode <br />
+      <Sun size={20} className="vertical-align-icons" /> - switch to the light mode <br />
       <ArrowDownCircle size={20} className="vertical-align-icons" /> - jump to a section of an
       operating system <br />
       <Filter size={20} className="vertical-align-icons" /> - filter for not yet translated or
@@ -82,7 +92,7 @@ const IconActionHelp = () => {
           }}
         />
       </Tooltip>
-      <Modal {...bindings} width="800px">
+      <Modal {...bindings} width="1000px">
         <Modal.Title>Information</Modal.Title>
         <Modal.Subtitle>about this project</Modal.Subtitle>
         <Modal.Content>

--- a/resources/src/IconActionTheme.tsx
+++ b/resources/src/IconActionTheme.tsx
@@ -1,17 +1,17 @@
 import { useContext } from 'react'
 import { Tooltip } from '@geist-ui/react'
 import { Moon, Sun } from '@geist-ui/react-icons'
-import { ThemeTypeContext } from './ThemeType'
+import { ThemeType, ThemeTypeContext } from './ThemeType'
 
 const IconActionTheme = (props: { side?: boolean }) => {
   const { themeType, setThemeType } = useContext(ThemeTypeContext)
 
   const placement = props.side ? 'left' : 'top'
   const icon =
-    themeType === 'light' ? (
-      <Moon className="cursor-pointer" size={28} onClick={() => setThemeType('dark')} />
+    themeType === ThemeType.Light ? (
+      <Moon className="cursor-pointer" size={28} onClick={() => setThemeType(ThemeType.Dark)} />
     ) : (
-      <Sun className="cursor-pointer" size={28} onClick={() => setThemeType('light')} />
+      <Sun className="cursor-pointer" size={28} onClick={() => setThemeType(ThemeType.Light)} />
     )
 
   return (

--- a/resources/src/IconActionTheme.tsx
+++ b/resources/src/IconActionTheme.tsx
@@ -1,0 +1,24 @@
+import { useContext } from 'react'
+import { Tooltip } from '@geist-ui/react'
+import { Moon, Sun } from '@geist-ui/react-icons'
+import { ThemeTypeContext } from './ThemeType'
+
+const IconActionTheme = (props: { side?: boolean }) => {
+  const { themeType, setThemeType } = useContext(ThemeTypeContext)
+
+  const placement = props.side ? 'left' : 'top'
+  const icon =
+    themeType === 'light' ? (
+      <Moon className="cursor-pointer" size={28} onClick={() => setThemeType('dark')} />
+    ) : (
+      <Sun className="cursor-pointer" size={28} onClick={() => setThemeType('light')} />
+    )
+
+  return (
+    <Tooltip text="Change theme" placement={placement} enterDelay={0}>
+      {icon}
+    </Tooltip>
+  )
+}
+
+export { IconActionTheme }

--- a/resources/src/IconActions.css
+++ b/resources/src/IconActions.css
@@ -9,6 +9,10 @@
   background: rgba(255, 255, 255, 0.9);
 }
 
+.dark .floating-right {
+  background: rgba(0, 0, 0, 0.5);
+}
+
 .hidden {
   display: none;
 }

--- a/resources/src/IconActions.css
+++ b/resources/src/IconActions.css
@@ -10,7 +10,7 @@
 }
 
 .dark .floating-right {
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.7);
 }
 
 .hidden {

--- a/resources/src/IconActions.tsx
+++ b/resources/src/IconActions.tsx
@@ -1,6 +1,7 @@
-import { Grid } from '@geist-ui/react'
+import { Col, Grid, Row } from '@geist-ui/react'
 import { useInView } from 'react-intersection-observer'
 import { IconActionHelp } from './IconActionHelp'
+import { IconActionTheme } from './IconActionTheme'
 import { IconActionJump } from './IconActionJump'
 import { IconActionFilter } from './IconActionFilter'
 import { IconActionHighlight } from './IconActionHighlight'
@@ -23,16 +24,32 @@ const IconActions = () => {
             <IconActionHelp />
           </Grid>
           <Grid>
-            <IconActionJump />
-            <IconActionFilter />
-            <IconActionHighlight />
-            <IconActionSearch />
+            <Row gap={0.5}>
+              <Col>
+                <IconActionTheme />
+              </Col>
+              <Col>
+                <IconActionJump />
+              </Col>
+              <Col>
+                <IconActionFilter />
+              </Col>
+              <Col>
+                <IconActionHighlight />
+              </Col>
+              <Col>
+                <IconActionSearch />
+              </Col>
+            </Row>
           </Grid>
         </Grid.Container>
       </div>
 
       <div className={floatingClasses}>
         <Grid.Container direction="column" gap={0.5}>
+          <Grid>
+            <IconActionTheme side />
+          </Grid>
           <Grid>
             <IconActionSearch side />
           </Grid>

--- a/resources/src/Table.css
+++ b/resources/src/Table.css
@@ -10,21 +10,41 @@
   background: rgba(128, 187, 255, 0.35);
 }
 
+.dark .background-blue {
+  background: rgba(22, 27, 32, 0.8);
+}
+
 .background-green {
   background: rgba(113, 186, 93, 0.35);
+}
+
+.dark .background-green {
+  background: rgba(28, 81, 44, 0.8);
 }
 
 .background-yellow {
   background: rgba(245, 198, 122, 0.35);
 }
 
+.dark .background-yellow {
+  background: rgba(121, 103, 19, 0.8);
+}
+
 .background-red {
   background: rgba(255, 128, 128, 0.35);
+}
+
+.dark .background-red {
+  background: rgba(89, 37, 38, 0.8);
 }
 
 /* An element has the class 'background-blue' and one of its child elements is 'highlighted'.  */
 .background-blue .highlighted {
   background: rgba(128, 187, 255, 0.55);
+}
+
+.dark .background-blue .highlighted {
+  background: rgba(22, 27, 32, 1);
 }
 
 /*
@@ -35,16 +55,35 @@
   background: rgba(113, 186, 93, 0.55);
 }
 
+.dark .background-green.highlighted {
+  background: rgba(28, 81, 44, 1);
+}
+
 .background-yellow.highlighted {
   background: rgba(245, 198, 122, 0.55);
+}
+
+.dark .background-yellow.highlighted {
+  background: rgba(121, 103, 19, 1);
 }
 
 .background-red.highlighted {
   background: rgba(255, 128, 128, 0.55);
 }
 
+.dark .background-red.highlighted {
+  background: rgba(89, 37, 38, 1);
+}
+
 .bg-white-transparent {
   background: rgba(255, 255, 255, 0.9);
+  -moz-background-clip: padding;
+  -webkit-background-clip: padding;
+  background-clip: padding-box;
+}
+
+.dark .bg-white-transparent {
+  background: rgba(0, 0, 0, 0.9);
   -moz-background-clip: padding;
   -webkit-background-clip: padding;
   background-clip: padding-box;
@@ -57,8 +96,22 @@
   background-clip: padding-box;
 }
 
+.dark .bg-white-transparent.highlighted {
+  background: rgba(22, 27, 32, 0.9);
+  -moz-background-clip: padding;
+  -webkit-background-clip: padding;
+  background-clip: padding-box;
+}
+
 .bg-white-opaque {
   background: rgba(255, 255, 255, 1);
+  -moz-background-clip: padding;
+  -webkit-background-clip: padding;
+  background-clip: padding-box;
+}
+
+.dark .bg-white-opaque {
+  background: rgba(0, 0, 0, 1);
   -moz-background-clip: padding;
   -webkit-background-clip: padding;
   background-clip: padding-box;
@@ -82,8 +135,17 @@ th {
   padding: 2px;
 }
 
+.dark td,
+.dark th {
+  border: 0.5px solid rgba(33, 38, 45, 1);
+}
+
 tr:hover {
   background: rgba(179, 179, 179, 0.5);
+}
+
+.dark tr:hover {
+  background: rgba(102, 102, 102, 0.4);
 }
 
 .sticky {

--- a/resources/src/ThemeType.tsx
+++ b/resources/src/ThemeType.tsx
@@ -1,30 +1,35 @@
 import { createContext, PropsWithChildren, useContext, useEffect, useState } from 'react'
 
+enum ThemeType {
+  Light = 'light',
+  Dark = 'dark',
+}
+
 const ThemeTypeContext = createContext<{
-  themeType: string
-  setThemeType: (themeType: string) => void
+  themeType: ThemeType
+  setThemeType: (themeType: ThemeType) => void
 }>({
-  themeType: 'light',
+  themeType: ThemeType.Light,
   setThemeType: () => {},
 })
 
 const ThemeTypeProvider = (props: PropsWithChildren<{}>) => {
-  const [themeType, setThemeType] = useState('light')
+  const [themeType, setThemeType] = useState(ThemeType.Light)
   const webStorageThemeTypeKey = 'theme-type'
 
   // Fetch the user preference using the Web Storage API or determine the system theme
   useEffect(() => {
     const stored = localStorage.getItem(webStorageThemeTypeKey)
-    if (stored === 'light' || stored === 'dark') {
+    if (stored === ThemeType.Light || stored === ThemeType.Dark) {
       setThemeType(stored)
     } else if (window && typeof window.matchMedia === 'function') {
       // Inspired by: https://github.com/xcv58/use-system-theme/blob/master/src/index.tsx
       const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-      setThemeType(isDark ? 'dark' : 'light')
+      setThemeType(isDark ? ThemeType.Dark : ThemeType.Light)
     }
   }, [])
 
-  const setPersistentThemeType = (themeType: string) => {
+  const setPersistentThemeType = (themeType: ThemeType) => {
     setThemeType(themeType)
     localStorage.setItem(webStorageThemeTypeKey, themeType)
   }
@@ -41,4 +46,4 @@ const useThemeType = () => {
   return themeType
 }
 
-export { ThemeTypeContext, ThemeTypeProvider, useThemeType }
+export { ThemeType, ThemeTypeContext, ThemeTypeProvider, useThemeType }

--- a/resources/src/ThemeType.tsx
+++ b/resources/src/ThemeType.tsx
@@ -1,0 +1,44 @@
+import { createContext, PropsWithChildren, useContext, useEffect, useState } from 'react'
+
+const ThemeTypeContext = createContext<{
+  themeType: string
+  setThemeType: (themeType: string) => void
+}>({
+  themeType: 'light',
+  setThemeType: () => {},
+})
+
+const ThemeTypeProvider = (props: PropsWithChildren<{}>) => {
+  const [themeType, setThemeType] = useState('light')
+  const webStorageThemeTypeKey = 'theme-type'
+
+  // Fetch the user preference using the Web Storage API or determine the system theme
+  useEffect(() => {
+    const stored = localStorage.getItem(webStorageThemeTypeKey)
+    if (stored === 'light' || stored === 'dark') {
+      setThemeType(stored)
+    } else if (window && typeof window.matchMedia === 'function') {
+      // Inspired by: https://github.com/xcv58/use-system-theme/blob/master/src/index.tsx
+      const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+      setThemeType(isDark ? 'dark' : 'light')
+    }
+  }, [])
+
+  const setPersistentThemeType = (themeType: string) => {
+    setThemeType(themeType)
+    localStorage.setItem(webStorageThemeTypeKey, themeType)
+  }
+
+  return (
+    <ThemeTypeContext.Provider value={{ themeType, setThemeType: setPersistentThemeType }}>
+      {props.children}
+    </ThemeTypeContext.Provider>
+  )
+}
+
+const useThemeType = () => {
+  const { themeType } = useContext(ThemeTypeContext)
+  return themeType
+}
+
+export { ThemeTypeContext, ThemeTypeProvider, useThemeType }


### PR DESCRIPTION
This pull request adds a dark mode to the website. 

Initially this setting is determined by the users system theme. If the user decides to change it using the moon / sun button, the selection is persisted.

Additionally the size of the title has increased and I widened the information modal, because I forget to apply the CSS properties of Geist UI (`<CssBaseline />`). I've also increased the gap between each action icon on the top.

Preview: https://deploy-preview-14--tldr-i18n-progress-preview.netlify.app

I'm interested in your opinion about the colors for the dark mode. Do they look good on your screen?

Closes #13 